### PR TITLE
Portability fixes for Linux and headless sessions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ Getting started
 ---------------
 
 * First you'll need to setup an `R environment <http://www.r-project.org/>`_.
-  We have currently only tested with R 3.0.3. There are known issues in R 3.0.2
-  and R 3.1.0.
+  We have currently only tested with R 3.0.3 and R 3.1.0. There are known issues
+  in R 3.0.2.
 
 * Then you'll need a valid client ID and secret. Follow the `authentication
   instructions <https://developers.google.com/genomics#authenticate>`_,

--- a/genomics-api.R
+++ b/genomics-api.R
@@ -15,13 +15,19 @@
 # This is a "client ID for native application" id and secret from the Google Developer's console
 # (console.developers.google.com). Make sure you pass in your own values.
 setup <- function(clientId="...googleusercontent.com", clientSecret) {
+  # Package type as determined by the platform. Source for Linux, and preference to binary for others.
+  pkgType <- getOption("pkgType")
+  if (grepl(pkgType, "binary")) {
+    pkgType <- "both"
+  }
+
   # Cran packages
   update.packages()
   cranPkgs <- c("rjson", "httr")
   cranInstallPkgs <- c(cranPkgs, "jsonlite", "httpuv") # Runtime dependencies
   cranInstallPkgs <- cranInstallPkgs[!cranInstallPkgs %in% installed.packages()]
   if (length(cranInstallPkgs) > 0)
-    install.packages(cranInstallPkgs, type="both")
+    install.packages(cranInstallPkgs, type=pkgType)
   sapply(cranPkgs, library, character.only=TRUE)
  
   # Bioconductor packages
@@ -35,12 +41,12 @@ setup <- function(clientId="...googleusercontent.com", clientSecret) {
 
   biocLiteInstallPkgs <- biocLitePkgs[!biocLitePkgs %in% installed.packages()]
   if (length(biocLiteInstallPkgs) > 0)
-    biocLite(biocLiteInstallPkgs, type="both")
+    biocLite(biocLiteInstallPkgs, type=pkgType)
   sapply(biocLitePkgs, library, character.only=TRUE)
 
   app <- oauth_app("google", clientId, clientSecret)
   google_token <<- oauth2.0_token(oauth_endpoints("google"), app,
-      scope = "https://www.googleapis.com/auth/genomics")
+      scope = "https://www.googleapis.com/auth/genomics", use_oob=TRUE)
 }
 
 # By default, this function encompasses 2 chromosome positions which relate to ApoE
@@ -50,7 +56,8 @@ getReadData <- function(chromosome="chr19", start=45411941, end=45412079,
     pageToken=NULL) {
     	
   # Fetch data from the Genomics API  	
-  body <- list(readsetIds=list(readsetId), sequenceName=chromosome, sequenceStart=start, sequenceEnd=end, pageToken=pageToken)  	
+  body <- list(readsetIds=list(readsetId), sequenceName=chromosome, sequenceStart=start,
+      sequenceEnd=end, pageToken=pageToken)
     	
   message("Fetching read data page")
     	


### PR DESCRIPTION
This will make package installation work on Linux, and in ssh sessions without X11 forwarding. The URL will need to be manually copy pasted into a browser, and the auth code copied back into the R session. After discussion with @craigcitro, there was no elegant way to automatically determine whether the user would want the graphical browser automatically invoked or not. For example, the user can be in a screen session with the DISPLAY env set but is now ssh-ing into the screen session so has no access to the opened browser window. Another way will be to prompt the user what he wants, which can be a future improvement.
