### PR TITLE
Update README.rst R "library" -> "package"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,8 +95,8 @@ Project status
 
 Goals
 ~~~~~
-* Provide an R library that hooks up the Genomics APIs to all of the other
-  great existing R tools for biology. This library should be consumable by
+* Provide an R package that hooks up the Genomics APIs to all of the other
+  great existing R tools for biology. This package should be consumable by
   R developers.
 * In addition, for non-developers, provide many Read and Variant analysis
   samples that can easily be run on API data without requiring a lot of prior


### PR DESCRIPTION
Perhaps pedantry, but R has _packages_ which are installed into _libraries_. Also, using "package" helps to avoid confusion between those and system libraries required to run certain packages.
